### PR TITLE
Correct dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": ">=5.1"
+        "illuminate/support": ">=5.2"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~4.0",
-        "laravel/laravel": ">=5.1"
+        "laravel/laravel": ">=5.2"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Pluck in Illuminate 5.1 returns mixed, which can cause an error: https://laravel.com/api/5.1/Illuminate/Database/Query/Builder.html#method_pluck

Switched the 2.x dependency to >=5.2 to resolve.